### PR TITLE
Rename 'fb' in classnames and ids to 'form-builder'

### DIFF
--- a/index.md
+++ b/index.md
@@ -13,10 +13,10 @@ Formbuilder is a graphical interface for letting users build their own webforms.
 
 ## Basic usage
 {% highlight html %}
-<div class='fb-main'></div>
+<div class='form-builder-main'></div>
 
 <script>
-var fb = new Formbuilder('.fb-main');
+var builder = new Formbuilder('.form-builder-main');
 </script>
 {% endhighlight %}
 
@@ -41,9 +41,9 @@ More coming soon...
 
 #### `save`
 {% highlight html %}
-var fb = new Formbuilder('#fb');
+var builder = new Formbuilder('#form-builder');
 
-fb.on('save', function(payload){
+builder.on('save', function(payload){
   ...
 });
 {% endhighlight %}


### PR DESCRIPTION
FB might be an appropriate abbreviation for FormBuilder, but it is far to easy to get it confused with Facebook. 

At least I was a little confused when I read the examples ("What has this to do with FB?").
