### PR TITLE
Fix scrolling if Form builder is not at the top of the page. 

### DIFF
--- a/dist/formbuilder.js
+++ b/dist/formbuilder.js
@@ -314,7 +314,7 @@
         if (_this.$fbLeft.data('locked') === true) {
           return;
         }
-        newMargin = Math.max(0, $(window).scrollTop());
+        newMargin = Math.max(0, $(window).scrollTop() - _this.$el.offset().top);
         maxMargin = _this.$responseFields.height();
         return _this.$fbLeft.css({
           'margin-top': Math.min(maxMargin, newMargin)
@@ -462,7 +462,7 @@
       if (!$responseFieldEl[0]) {
         return;
       }
-      return $.scrollWindowTo($responseFieldEl.offset().top - this.$responseFields.offset().top, 200, function() {
+      return $.scrollWindowTo((this.$el.offset().top + $responseFieldEl.offset().top) - this.$responseFields.offset().top, 200, function() {
         return _this.lockLeftWrapper();
       });
     };

--- a/src/scripts/main.coffee
+++ b/src/scripts/main.coffee
@@ -175,7 +175,7 @@ class BuilderView extends Backbone.View
   bindWindowScrollEvent: ->
     $(window).on 'scroll', =>
       return if @$fbLeft.data('locked') == true
-      newMargin = Math.max(0, $(window).scrollTop())
+      newMargin = Math.max(0, $(window).scrollTop() - @$el.offset().top)
       maxMargin = @$responseFields.height()
 
       @$fbLeft.css
@@ -297,7 +297,7 @@ class BuilderView extends Backbone.View
   scrollLeftWrapper: ($responseFieldEl) ->
     @unlockLeftWrapper()
     return unless $responseFieldEl[0]
-    $.scrollWindowTo ($responseFieldEl.offset().top - @$responseFields.offset().top), 200, =>
+    $.scrollWindowTo ((@$el.offset().top + $responseFieldEl.offset().top) - @$responseFields.offset().top), 200, =>
       @lockLeftWrapper()
 
   lockLeftWrapper: ->


### PR DESCRIPTION
All this does is calculates the scrolls position based upon the container.  Instead of just assuming the distance to the top of the page = the top of the form builder.  
