### PR TITLE
Compatibility with jQuery in noconflict mode (as you'd see in WordPress)

### DIFF
--- a/dist/formbuilder.js
+++ b/dist/formbuilder.js
@@ -483,7 +483,7 @@
       if (!$responseFieldEl[0]) {
         return;
       }
-      return $.scrollWindowTo((this.$el.offset().top + $responseFieldEl.offset().top) - this.$responseFields.offset().top, 200, function() {
+      return jQuery.scrollWindowTo((this.$el.offset().top + $responseFieldEl.offset().top) - this.$responseFields.offset().top, 200, function() {
         return _this.lockLeftWrapper();
       });
     };
@@ -523,7 +523,7 @@
 
     BuilderView.prototype.doAjaxSave = function(payload) {
       var _this = this;
-      return $.ajax({
+      return jQuery.ajax({
         url: Formbuilder.options.HTTP_ENDPOINT,
         type: Formbuilder.options.HTTP_METHOD,
         data: payload,

--- a/dist/formbuilder.js
+++ b/dist/formbuilder.js
@@ -3,10 +3,10 @@
     publishes: true,
     routine: rivets.binders.value.routine,
     bind: function(el) {
-      return $(el).bind('input.rivets', this.publish);
+      return jQuery(el).bind('input.rivets', this.publish);
     },
     unbind: function(el) {
-      return $(el).unbind('input.rivets');
+      return jQuery(el).unbind('input.rivets');
     }
   };
 
@@ -58,10 +58,10 @@
     FormbuilderModel.prototype.indexInDOM = function() {
       var $wrapper,
         _this = this;
-      $wrapper = $(".fb-field-wrapper").filter((function(_, el) {
-        return $(el).data('cid') === _this.cid;
+      $wrapper = jQuery(".fb-field-wrapper").filter((function(_, el) {
+        return jQuery(el).data('cid') === _this.cid;
       }));
-      return $(".fb-field-wrapper").index($wrapper);
+      return jQuery(".fb-field-wrapper").index($wrapper);
     };
 
     FormbuilderModel.prototype.is_input = function() {
@@ -208,7 +208,7 @@
 
     EditFieldView.prototype.addOption = function(e) {
       var $el, i, newOption, options;
-      $el = $(e.currentTarget);
+      $el = jQuery(e.currentTarget);
       i = this.$el.find('.option').index($el.closest('.option'));
       options = this.model.get(Formbuilder.options.mappings.OPTIONS) || [];
       newOption = {
@@ -227,7 +227,7 @@
 
     EditFieldView.prototype.removeOption = function(e) {
       var $el, index, options;
-      $el = $(e.currentTarget);
+      $el = jQuery(e.currentTarget);
       index = this.$el.find(".js-remove-option").index($el);
       options = this.model.get(Formbuilder.options.mappings.OPTIONS);
       options.splice(index, 1);
@@ -238,7 +238,7 @@
 
     EditFieldView.prototype.defaultUpdated = function(e) {
       var $el;
-      $el = $(e.currentTarget);
+      $el = jQuery(e.currentTarget);
       if (this.model.get(Formbuilder.options.mappings.FIELD_TYPE) !== 'checkboxes') {
         this.$el.find(".js-default-updated").not($el).attr('checked', false).trigger('change');
       }
@@ -275,7 +275,7 @@
       var selector;
       selector = options.selector, this.formBuilder = options.formBuilder, this.bootstrapData = options.bootstrapData;
       if (selector != null) {
-        this.setElement($(selector));
+        this.setElement(jQuery(selector));
       }
       this.collection = new FormbuilderCollection;
       this.collection.bind('add', this.addOne, this);
@@ -298,7 +298,7 @@
           return _this.saveForm.call(_this);
         }, 5000);
       }
-      return $(window).bind('beforeunload', function() {
+      return jQuery(window).bind('beforeunload', function() {
         if (_this.formSaved) {
           return void 0;
         } else {
@@ -331,12 +331,12 @@
 
     BuilderView.prototype.bindWindowScrollEvent = function() {
       var _this = this;
-      return $(window).on('scroll', function() {
+      return jQuery(window).on('scroll', function() {
         var maxMargin, newMargin;
         if (_this.$fbLeft.data('locked') === true) {
           return;
         }
-        newMargin = Math.max(0, $(window).scrollTop() - _this.$el.offset().top);
+        newMargin = Math.max(0, jQuery(window).scrollTop() - _this.$el.offset().top);
         maxMargin = _this.$responseFields.height();
         return _this.$fbLeft.css({
           'margin-top': Math.min(maxMargin, newMargin)
@@ -346,10 +346,10 @@
 
     BuilderView.prototype.showTab = function(e) {
       var $el, first_model, target;
-      $el = $(e.currentTarget);
+      $el = jQuery(e.currentTarget);
       target = $el.data('target');
       $el.closest('li').addClass('active').siblings('li').removeClass('active');
-      $(target).addClass('active').siblings('.fb-tab-pane').removeClass('active');
+      jQuery(target).addClass('active').siblings('.fb-tab-pane').removeClass('active');
       if (target !== '#editField') {
         this.unlockLeftWrapper();
       }
@@ -413,7 +413,7 @@
         connectToSortable: this.$responseFields,
         helper: function() {
           var $helper;
-          $helper = $("<div class='response-field-draggable-helper' />");
+          $helper = jQuery("<div class='response-field-draggable-helper' />");
           $helper.css({
             width: _this.$responseFields.width(),
             height: '80px'
@@ -434,7 +434,7 @@
 
     BuilderView.prototype.addField = function(e) {
       var field_type;
-      field_type = $(e.currentTarget).data('field-type');
+      field_type = jQuery(e.currentTarget).data('field-type');
       return this.createField(Formbuilder.helpers.defaultFieldAttrs(field_type));
     };
 
@@ -448,7 +448,7 @@
     BuilderView.prototype.createAndShowEditView = function(model) {
       var $newEditEl, $responseFieldEl;
       $responseFieldEl = this.$el.find(".fb-field-wrapper").filter(function() {
-        return $(this).data('cid') === model.cid;
+        return jQuery(this).data('cid') === model.cid;
       });
       $responseFieldEl.addClass('editing').siblings('.fb-field-wrapper').removeClass('editing');
       if (this.editView) {
@@ -474,7 +474,7 @@
       if (!this.editView) {
         return;
       }
-      return this.scrollLeftWrapper($(".fb-field-wrapper.editing"));
+      return this.scrollLeftWrapper(jQuery(".fb-field-wrapper.editing"));
     };
 
     BuilderView.prototype.scrollLeftWrapper = function($responseFieldEl) {

--- a/src/scripts/main.coffee
+++ b/src/scripts/main.coffee
@@ -313,7 +313,7 @@ class BuilderView extends Backbone.View
   scrollLeftWrapper: ($responseFieldEl) ->
     @unlockLeftWrapper()
     return unless $responseFieldEl[0]
-    $.scrollWindowTo ((@$el.offset().top + $responseFieldEl.offset().top) - @$responseFields.offset().top), 200, =>
+    jQuery.scrollWindowTo ((@$el.offset().top + $responseFieldEl.offset().top) - @$responseFields.offset().top), 200, =>
       @lockLeftWrapper()
 
   lockLeftWrapper: ->
@@ -338,7 +338,7 @@ class BuilderView extends Backbone.View
     @formBuilder.trigger 'save', payload
 
   doAjaxSave: (payload) ->
-    $.ajax
+    jQuery.ajax
       url: Formbuilder.options.HTTP_ENDPOINT
       type: Formbuilder.options.HTTP_METHOD
       data: payload

--- a/src/scripts/main.coffee
+++ b/src/scripts/main.coffee
@@ -1,8 +1,8 @@
 class FormbuilderModel extends Backbone.DeepModel
   sync: -> # noop
   indexInDOM: ->
-    $wrapper = $(".fb-field-wrapper").filter ( (_, el) => $(el).data('cid') == @cid  )
-    $(".fb-field-wrapper").index $wrapper
+    $wrapper = jQuery(".fb-field-wrapper").filter ( (_, el) => jQuery(el).data('cid') == @cid  )
+    jQuery(".fb-field-wrapper").index $wrapper
   is_input: ->
     Formbuilder.inputFields[@get(Formbuilder.options.mappings.FIELD_TYPE)]?
 
@@ -93,7 +93,7 @@ class EditFieldView extends Backbone.View
 
   # @todo this should really be on the model, not the view
   addOption: (e) ->
-    $el = $(e.currentTarget)
+    $el = jQuery(e.currentTarget)
     i = @$el.find('.option').index($el.closest('.option'))
     options = @model.get(Formbuilder.options.mappings.OPTIONS) || []
     newOption = {label: "", checked: false}
@@ -108,7 +108,7 @@ class EditFieldView extends Backbone.View
     @forceRender()
 
   removeOption: (e) ->
-    $el = $(e.currentTarget)
+    $el = jQuery(e.currentTarget)
     index = @$el.find(".js-remove-option").index($el)
     options = @model.get Formbuilder.options.mappings.OPTIONS
     options.splice index, 1
@@ -117,7 +117,7 @@ class EditFieldView extends Backbone.View
     @forceRender()
 
   defaultUpdated: (e) ->
-    $el = $(e.currentTarget)
+    $el = jQuery(e.currentTarget)
 
     unless @model.get(Formbuilder.options.mappings.FIELD_TYPE) == 'checkboxes' # checkboxes can have multiple options selected
       @$el.find(".js-default-updated").not($el).attr('checked', false).trigger('change')
@@ -143,7 +143,7 @@ class BuilderView extends Backbone.View
 
     # This is a terrible idea because it's not scoped to this view.
     if selector?
-      @setElement $(selector)
+      @setElement jQuery(selector)
 
     # Create the collection, and bind the appropriate events
     @collection = new FormbuilderCollection
@@ -167,7 +167,7 @@ class BuilderView extends Backbone.View
         @saveForm.call(@)
       , 5000
 
-    $(window).bind 'beforeunload', =>
+    jQuery(window).bind 'beforeunload', =>
       if @formSaved then undefined else Formbuilder.options.dict.UNSAVED_CHANGES
 
   reset: ->
@@ -190,19 +190,19 @@ class BuilderView extends Backbone.View
     return @
 
   bindWindowScrollEvent: ->
-    $(window).on 'scroll', =>
+    jQuery(window).on 'scroll', =>
       return if @$fbLeft.data('locked') == true
-      newMargin = Math.max(0, $(window).scrollTop() - @$el.offset().top)
+      newMargin = Math.max(0, jQuery(window).scrollTop() - @$el.offset().top)
       maxMargin = @$responseFields.height()
 
       @$fbLeft.css
         'margin-top': Math.min(maxMargin, newMargin)
 
   showTab: (e) ->
-    $el = $(e.currentTarget)
+    $el = jQuery(e.currentTarget)
     target = $el.data('target')
     $el.closest('li').addClass('active').siblings('li').removeClass('active')
-    $(target).addClass('active').siblings('.fb-tab-pane').removeClass('active')
+    jQuery(target).addClass('active').siblings('.fb-tab-pane').removeClass('active')
 
     @unlockLeftWrapper() unless target == '#editField'
 
@@ -261,7 +261,7 @@ class BuilderView extends Backbone.View
     $addFieldButtons.draggable
       connectToSortable: @$responseFields
       helper: =>
-        $helper = $("<div class='response-field-draggable-helper' />")
+        $helper = jQuery("<div class='response-field-draggable-helper' />")
         $helper.css
           width: @$responseFields.width() # hacky, won't get set without inline style
           height: '80px'
@@ -276,7 +276,7 @@ class BuilderView extends Backbone.View
     @$el.find(".fb-no-response-fields")[if @collection.length > 0 then 'hide' else 'show']()
 
   addField: (e) ->
-    field_type = $(e.currentTarget).data('field-type')
+    field_type = jQuery(e.currentTarget).data('field-type')
     @createField Formbuilder.helpers.defaultFieldAttrs(field_type)
 
   createField: (attrs, options) ->
@@ -285,7 +285,7 @@ class BuilderView extends Backbone.View
     @handleFormUpdate()
 
   createAndShowEditView: (model) ->
-    $responseFieldEl = @$el.find(".fb-field-wrapper").filter( -> $(@).data('cid') == model.cid )
+    $responseFieldEl = @$el.find(".fb-field-wrapper").filter( -> jQuery(@).data('cid') == model.cid )
     $responseFieldEl.addClass('editing').siblings('.fb-field-wrapper').removeClass('editing')
 
     if @editView
@@ -308,7 +308,7 @@ class BuilderView extends Backbone.View
 
   ensureEditViewScrolled: ->
     return unless @editView
-    @scrollLeftWrapper $(".fb-field-wrapper.editing")
+    @scrollLeftWrapper jQuery(".fb-field-wrapper.editing")
 
   scrollLeftWrapper: ($responseFieldEl) ->
     @unlockLeftWrapper()

--- a/src/scripts/rivets-config.coffee
+++ b/src/scripts/rivets-config.coffee
@@ -2,9 +2,9 @@ rivets.binders.input =
   publishes: true
   routine: rivets.binders.value.routine
   bind: (el) ->
-    $(el).bind('input.rivets', this.publish)
+    jQuery(el).bind('input.rivets', this.publish)
   unbind: (el) ->
-    $(el).unbind('input.rivets')
+    jQuery(el).unbind('input.rivets')
 
 rivets.configure
   prefix: "rv"


### PR DESCRIPTION
I'm using formbuilder as part of the admin interface to a WordPress plugin. Since WordPress runs jQuery in noconflict mode, the $ shortcut isn't available. This PR just replaces calls to $() with calls to jQuery() so it works in noconflict mode or otherwise.
